### PR TITLE
Wrap errors with %w consistently

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -117,7 +117,7 @@ func (c *Client) httpPostJWS(ctx context.Context, privateKey crypto.Signer,
 		break
 	}
 
-	return resp, fmt.Errorf("request to %s failed after %d attempts: %v",
+	return resp, fmt.Errorf("request to %s failed after %d attempts: %w",
 		endpoint, attempts, err)
 }
 


### PR DESCRIPTION
I noticed acmez was using a mixture of %v and %w to wrap errors, which caused problems when I was trying to use errors.As() after calling certain functions.

I've gone through all the fmt.Errorf() calls, replacing %v with %w where appropriate.