### PR TITLE
add get order method

### DIFF
--- a/acme/order.go
+++ b/acme/order.go
@@ -120,10 +120,7 @@ func (c *Client) GetOrder(ctx context.Context, account Account, order Order) (Or
 		return order, err
 	}
 	_, err := c.httpPostJWS(ctx, account.PrivateKey, account.Location, order.Location, nil, &order)
-	if err != nil {
-		return order, err
-	}
-	return order, nil
+	return order, err
 }
 
 // FinalizeOrder finalizes the order with the server and polls under the server has

--- a/acme/order.go
+++ b/acme/order.go
@@ -114,6 +114,21 @@ func (c *Client) NewOrder(ctx context.Context, account Account, order Order) (Or
 	return order, nil
 }
 
+// GetOrder get a order with the server.
+//
+// "The client begins the certificate issuance process by sending a POST as GET
+// request to the server's order resource." §7.4
+func (c *Client) GetOrder(ctx context.Context, account Account, order Order) (Order, error) {
+	if err := c.provision(ctx); err != nil {
+		return order, err
+	}
+	_, err := c.httpPostJWS(ctx, account.PrivateKey, account.Location, order.Location, nil, &order)
+	if err != nil {
+		return order, err
+	}
+	return order, nil
+}
+
 // FinalizeOrder finalizes the order with the server and polls under the server has
 // updated the order status. The CSR must be in ASN.1 DER-encoded format. If this
 // succeeds, the certificate is ready to download once this returns.

--- a/acme/order.go
+++ b/acme/order.go
@@ -114,7 +114,7 @@ func (c *Client) NewOrder(ctx context.Context, account Account, order Order) (Or
 	return order, nil
 }
 
-// GetOrder get a order with the server.
+// GetOrder retrieves an order from the server. The Order's Location field must be populated.
 //
 // "The client begins the certificate issuance process by sending a POST as GET
 // request to the server's order resource." §7.4

--- a/acme/order.go
+++ b/acme/order.go
@@ -115,9 +115,6 @@ func (c *Client) NewOrder(ctx context.Context, account Account, order Order) (Or
 }
 
 // GetOrder retrieves an order from the server. The Order's Location field must be populated.
-//
-// "The client begins the certificate issuance process by sending a POST as GET
-// request to the server's order resource." §7.4
 func (c *Client) GetOrder(ctx context.Context, account Account, order Order) (Order, error) {
 	if err := c.provision(ctx); err != nil {
 		return order, err


### PR DESCRIPTION
I want make an api service for cert request for those who want get certificate use dns TXT records manually, like this steps:
1. send request and return TXT records
2. add TXT records manually from their dns servers
3. solve the challenge
4. get certificate

If we do not have a get order method, we can't get the order  created from step 1, these will create a lot of invalid new orders, so I want to add a get order method, we just need to set the order's Location prop before call `GetOrder` method. 

Hope to be merged. I have tested that method works!