### PR TITLE
Use correct error variable in logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -499,7 +499,7 @@ func (c *Client) pollAuthorization(ctx context.Context, account acme.Account, au
 			c.Logger.Error("cleaning up solver",
 				zap.String("identifier", authz.IdentifierValue()),
 				zap.String("challenge_type", authz.currentChallenge.Type),
-				zap.Error(err))
+				zap.Error(cleanupErr))
 		}
 		authz.currentSolver = nil // avoid cleaning it up again later
 	}


### PR DESCRIPTION
This could help investigate more for https://github.com/caddy-dns/route53/issues/15

# Scenario
* Using Caddy server with DNS01 Challenge on Route53 for wildcard certificate
* Restarting Caddy gives error and shows error which can be ignored, as it was restarted and has no memory of that record.
* Certificate fails because the TXT record already exists from previous ACME Challenge.
* After removing TXT record manually, logs doesn't show error while cleaning up, hence the pull request.

# Logs
Just before the last log, I removed the TXT record manually and it issued the certificate but didn't log the error.

```json
{"level":"error","ts":1648681778.6813097,"logger":"tls.issuance.acme.acme_client","msg":"cleaning up solver","identifier":"*.redacted.com","challenge_type":"dns-01","error":"no memory of presenting a DNS record for redacted.com (probably OK if presenting failed)"}
{"level":"error","ts":1648703379.4469087,"logger":"tls.issuance.acme.acme_client","msg":"cleaning up solver","identifier":"*.redacted.com","challenge_type":"dns-01","error":"no memory of presenting a DNS record for redacted.com (probably OK if presenting failed)"}
{"level":"error","ts":1648707063.9319153,"logger":"tls.issuance.acme.acme_client","msg":"cleaning up solver","identifier":"*.redacted.com","challenge_type":"dns-01","error":"no memory of presenting a DNS record for redacted.com (probably OK if presenting failed)"}
{"level":"error","ts":1648707125.6041455,"logger":"tls.issuance.acme.acme_client","msg":"cleaning up solver","identifier":"*.redacted.com","challenge_type":"dns-01","error":"no memory of presenting a DNS record for redacted.com (probably OK if presenting failed)"}
{"level":"error","ts":1648707334.841073,"logger":"tls.issuance.acme.acme_client","msg":"cleaning up solver","identifier":"*.redacted.com","challenge_type":"dns-01"}
```