### PR TITLE
client - set initial order status to pending

### DIFF
--- a/acme/order.go
+++ b/acme/order.go
@@ -32,7 +32,7 @@ type Order struct {
 	// status (required, string):  The status of this order.  Possible
 	// values are "pending", "ready", "processing", "valid", and
 	// "invalid".  See Section 7.1.6.
-	Status string `json:"status"`
+	Status string `default:"pending";json:"status"`
 
 	// expires (optional, string):  The timestamp after which the server
 	// will consider this order invalid, encoded in the format specified

--- a/acme/order.go
+++ b/acme/order.go
@@ -32,7 +32,7 @@ type Order struct {
 	// status (required, string):  The status of this order.  Possible
 	// values are "pending", "ready", "processing", "valid", and
 	// "invalid".  See Section 7.1.6.
-	Status string `default:"pending";json:"status"`
+	Status string `json:"status,omitempty"`
 
 	// expires (optional, string):  The timestamp after which the server
 	// will consider this order invalid, encoded in the format specified

--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account ac
 	}
 
 	var err error
-	order := acme.Order{Identifiers: identifiers}
+	order := acme.Order{Identifiers: identifiers, Status: "pending"}
 
 	// remember which challenge types failed for which identifiers
 	// so we can retry with other challenge types

--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account ac
 	}
 
 	var err error
-	order := acme.Order{Identifiers: identifiers, Status: "pending"}
+	order := acme.Order{Identifiers: identifiers}
 
 	// remember which challenge types failed for which identifiers
 	// so we can retry with other challenge types


### PR DESCRIPTION
Hi,

as mentioned in https://github.com/noahkw/acmetk/issues/64 / https://github.com/caddyserver/caddy/issues/3539

the new-order payload send by acmez is questionable as the status is ""

```json
{"status":"","expires":"0001-01-01T00:00:00Z","identifiers":[{"type":"dns","value":"example.com"}],"authorizations":null,"finalize":"","certificate":""}
```
and considered invalid by acmetk.

I think this is correct due to
https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.3
https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.6
"" is not a possible value.

This patch initializes order.status.

I confimed acmetk will accept the order and grant a certificate using the porcelain example client.
