### PR TITLE
New v2 API for more customizable orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 acmez - ACME client library for Go
 ==================================
 
-[![godoc](https://pkg.go.dev/badge/github.com/mholt/acmez)](https://pkg.go.dev/github.com/mholt/acmez)
+[![godoc](https://pkg.go.dev/badge/github.com/mholt/acmez/v2)](https://pkg.go.dev/github.com/mholt/acmez/v2)
 
-ACMEz ("ack-measy" or "acme-zee", whichever you prefer) is a fully-compliant [RFC 8555](https://tools.ietf.org/html/rfc8555) (ACME) implementation in pure Go. It is lightweight, has an elegant Go API, and its retry logic is highly robust against external errors. ACMEz is suitable for large-scale enterprise deployments.
+ACMEz ("ack-measy" or "acme-zee", whichever you prefer) is a fully-compliant [RFC 8555](https://tools.ietf.org/html/rfc8555) (ACME) implementation in pure Go. It is lightweight, has an elegant Go API, and its retry logic is highly robust against external errors. ACMEz is suitable for large-scale enterprise deployments. It also supports common IETF-standardized ACME extensions.
 
-**NOTE:** This module is for _getting_ certificates, not _managing_ certificates. Most users probably want certificate _management_ (keeping certificates renewed) rather than to interface directly with ACME. Developers who want to use certificates in their long-running Go programs should use [CertMagic](https://github.com/caddyserver/certmagic) instead; or, if their program is not written in Go, [Caddy](https://caddyserver.com/) can be used to manage certificates (even without running an HTTP or TLS server).
+**NOTE:** This module is for _getting_ certificates, not _managing_ certificates. Most users probably want certificate _management_ (keeping certificates renewed) rather than to interface directly with ACME. Developers who want to use certificates in their long-running Go programs should use [CertMagic](https://github.com/caddyserver/certmagic) instead; or, if their program is not written in Go, [Caddy](https://caddyserver.com/) can be used to manage certificates (even without running an HTTP or TLS server if needed).
 
 This module has two primary packages:
 
@@ -27,11 +27,19 @@ In other words, the `acmez` package is **porcelain** while the `acme` package is
 - Highly flexible and customizable
 - External Account Binding (EAB) support
 - Tested with multiple ACME CAs (more than just Let's Encrypt)
-- Supports niche aspects of RFC 8555 (such as alt cert chains and account key rollover)
+- Implements niche aspects of RFC 8555 (such as alt cert chains and account key rollover)
 - Efficient solving of large SAN lists (e.g. for slow DNS record propagation)
 - Utility functions for solving challenges
 	- [Device attestation challenges](https://datatracker.ietf.org/doc/draft-acme-device-attest/)
 	- RFC 8737 (tls-alpn-01 challenge)
+- ACME Renewal Information (ARI) support (draft-ietf-acme-ari-03)
+
+
+## Install
+
+```
+go get github.com/mholt/acmez/v2
+```
 
 
 ## Examples

--- a/acme/account.go
+++ b/acme/account.go
@@ -25,12 +25,19 @@ import (
 // Account represents a set of metadata associated with an account
 // as defined by the ACME spec §7.1.2:
 // https://tools.ietf.org/html/rfc8555#section-7.1.2
+//
+// Users of this Go package should generally set Contact,
+// TermsOfServiceAgreed, ExternalAccountBinding if relevant,
+// and PrivateKey fields when creating a new account. Other
+// fields are populated by the ACME server.
 type Account struct {
 	// status (required, string):  The status of this account.  Possible
 	// values are "valid", "deactivated", and "revoked".  The value
 	// "deactivated" should be used to indicate client-initiated
 	// deactivation whereas "revoked" should be used to indicate server-
 	// initiated deactivation.  See Section 7.1.6.
+	//
+	// The client need NOT set this field when creating a new account.
 	Status string `json:"status"`
 
 	// contact (optional, array of string):  An array of URLs that the
@@ -70,6 +77,8 @@ type Account struct {
 	// The private key to the account. Because it is secret, it is
 	// not serialized as JSON and must be stored separately (usually
 	// a PEM-encoded file).
+	//
+	// This is a required field when creating a new account.
 	PrivateKey crypto.Signer `json:"-"`
 }
 

--- a/acme/ari.go
+++ b/acme/ari.go
@@ -87,7 +87,7 @@ func (c *Client) ariEndpoint(leafCert *x509.Certificate) string {
 
 // ARIUniqueIdentifier returns the unique identifier for the certificate
 // as used by ACME Renewal Information.
-// EXPERIMENTAL: ARI is a draft RFC spec: draft-ietf-acme-ari
+// EXPERIMENTAL: ARI is a draft RFC spec: draft-ietf-acme-ari-03
 func ARIUniqueIdentifier(leafCert *x509.Certificate) string {
 	return b64NoPad.EncodeToString(leafCert.AuthorityKeyId) + "." +
 		b64NoPad.EncodeToString(leafCert.SerialNumber.Bytes())

--- a/acme/ari.go
+++ b/acme/ari.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -83,9 +82,15 @@ func (c *Client) ariEndpoint(leafCert *x509.Certificate) string {
 	if leafCert == nil || leafCert.SerialNumber == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s/%s/%s", c.dir.RenewalInfo,
-		b64NoPad.EncodeToString(leafCert.AuthorityKeyId),
-		b64NoPad.EncodeToString(leafCert.SerialNumber.Bytes()))
+	return c.dir.RenewalInfo + "/" + ARIUniqueIdentifier(leafCert)
+}
+
+// ARIUniqueIdentifier returns the unique identifier for the certificate
+// as used by ACME Renewal Information.
+// EXPERIMENTAL: ARI is a draft RFC spec: draft-ietf-acme-ari
+func ARIUniqueIdentifier(leafCert *x509.Certificate) string {
+	return b64NoPad.EncodeToString(leafCert.AuthorityKeyId) + "." +
+		b64NoPad.EncodeToString(leafCert.SerialNumber.Bytes())
 }
 
 var b64NoPad = base64.URLEncoding.WithPadding(base64.NoPadding)

--- a/acme/order.go
+++ b/acme/order.go
@@ -51,8 +51,7 @@ type Order struct {
 	// this field in New Order requests if there is a clear predecessor
 	// certificate, as is the case for most certificate renewals.
 	//
-	// ACME EXTENSION. REFER TO:
-	// ACME Renewal Information (ARI) spec, draft-ietf-acme-ari-03.
+	// EXPERIMENTAL: ACME ARI EXTENSION: draft-ietf-acme-ari-03
 	Replaces string `json:"replaces,omitempty"`
 
 	// notBefore (optional, string):  The requested value of the notBefore

--- a/acme/order.go
+++ b/acme/order.go
@@ -51,7 +51,7 @@ type Order struct {
 	// this field in New Order requests if there is a clear predecessor
 	// certificate, as is the case for most certificate renewals.
 	//
-	// EXPERIMENTAL: ACME ARI EXTENSION: draft-ietf-acme-ari-03
+	// EXPERIMENTAL:  Draft ACME extension ARI: draft-ietf-acme-ari-03
 	Replaces string `json:"replaces,omitempty"`
 
 	// notBefore (optional, string):  The requested value of the notBefore

--- a/client.go
+++ b/client.go
@@ -33,21 +33,16 @@ package acmez
 import (
 	"context"
 	"crypto"
-	"crypto/rand"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	weakrand "math/rand"
-	"net"
-	"net/url"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/mholt/acmez/acme"
 	"go.uber.org/zap"
-	"golang.org/x/net/idna"
 )
 
 // Client is a high-level API for ACME operations. It wraps
@@ -61,31 +56,48 @@ type Client struct {
 	ChallengeSolvers map[string]Solver
 }
 
-// ObtainCertificateUsingCSRSource obtains all resulting certificate chains using the given
-// ACME Identifiers and the CSRSource. The CSRSource can be used to create and sign a final
-// CSR to be submitted to the ACME server just before finalization. The CSR  must be completely
-// and properly filled out, because the provided ACME Identifiers will be validated against
-// the Identifiers that can be extracted from the CSR. This package currently supports the
-// DNS, IP address, Permanent Identifier and Hardware Module Name identifiers. The Subject
-// CommonName is NOT considered.
-//
-// The CSR's Raw field containing the DER encoded signed certificate request must also be
-// set. This usually involves creating a template CSR, then calling x509.CreateCertificateRequest,
-// then x509.ParseCertificateRequest on the output.
-//
-// The method implements every single part of the ACME flow described in RFC 8555 §7.1 with the
-// exception of "Create account" because this method signature does not have a way to return
-// the updated account object. The account's status MUST be "valid" in order to succeed.
-func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account acme.Account, identifiers []acme.Identifier, source CSRSource) ([]acme.Certificate, error) {
-	if account.Status != acme.StatusValid {
-		return nil, fmt.Errorf("account status is not valid: %s", account.Status)
+// ObtainCertificateForSANs is a light wrapper over ObtainCertificate
+func (c *Client) ObtainCertificateForSANs(ctx context.Context, account acme.Account, certPrivateKey crypto.Signer, sans []string) ([]acme.Certificate, error) {
+	csr, err := NewCSR(certPrivateKey, sans)
+	if err != nil {
+		return nil, fmt.Errorf("generating CSR: %v", err)
 	}
-	if source == nil {
+	params, err := OrderParametersFromCSR(account, csr)
+	if err != nil {
+		return nil, fmt.Errorf("forming order parameters: %v", err)
+	}
+	return c.ObtainCertificate(ctx, params)
+}
+
+// ObtainCertificate obtains all certificate chains from the ACME server resulting from the
+// given order parameters. The private key passed in must be the one that was (or will
+// be) used to sign the CSR. The order parameters must be fully populated with an account,
+// a list of subject identifiers, and a CSR source; and the list of subject identifiers
+// must exactly match those in the CSR.
+//
+// The method implements every single part of the ACME flow described in RFC 8555 §7.1 with
+// the exception of "Create account" because account management is outside the scope of
+// certificate issuance. The account's status MUST be "valid" in order to succeed.
+func (c *Client) ObtainCertificate(ctx context.Context, params OrderParameters) ([]acme.Certificate, error) {
+	if params.Account.Status != acme.StatusValid {
+		return nil, fmt.Errorf("account status is not valid: %s", params.Account.Status)
+	}
+	if params.CSR == nil {
 		return nil, errors.New("missing CSR source")
 	}
+	if len(params.Subjects) == 0 {
+		return nil, errors.New("order does not list any subjects")
+	}
 
+	// create the ACME order
+	order := acme.Order{Identifiers: params.Subjects}
+	if !params.NotAfter.IsZero() {
+		order.NotAfter = &params.NotAfter
+	}
+
+	// prepare to retry the transaction multiple times if necessary
+	// until it succeeds
 	var err error
-	order := acme.Order{Identifiers: identifiers}
 
 	// remember which challenge types failed for which identifiers
 	// so we can retry with other challenge types
@@ -102,13 +114,13 @@ func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account ac
 		}
 
 		// create order for a new certificate
-		order, err = c.Client.NewOrder(ctx, account, order)
+		order, err = c.Client.NewOrder(ctx, params.Account, order)
 		if err != nil {
 			return nil, fmt.Errorf("creating new order: %w", err)
 		}
 
 		// solve one challenge for each authz on the order
-		err = c.solveChallenges(ctx, account, order, failedChallengeTypes)
+		err = c.solveChallenges(ctx, params.Account, order, failedChallengeTypes)
 
 		// yay, we win!
 		if err == nil {
@@ -148,8 +160,8 @@ func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account ac
 		c.Logger.Info("validations succeeded; finalizing order", zap.String("order", order.Location))
 	}
 
-	// get the CSR from its source
-	csr, err := source.CSR(ctx)
+	// get the CSR
+	csr, err := params.CSR.CSR(ctx, params.Subjects)
 	if err != nil {
 		return nil, fmt.Errorf("getting CSR from source: %w", err)
 	}
@@ -163,13 +175,13 @@ func (c *Client) ObtainCertificateUsingCSRSource(ctx context.Context, account ac
 	}
 
 	// finalize the order, which requests the CA to issue us a certificate
-	order, err = c.Client.FinalizeOrder(ctx, account, order, csr.Raw)
+	order, err = c.Client.FinalizeOrder(ctx, params.Account, order, csr.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("finalizing order %s: %w", order.Location, err)
 	}
 
 	// finally, download the certificate
-	certChains, err := c.Client.GetCertificateChain(ctx, account, order.Certificate)
+	certChains, err := c.Client.GetCertificateChain(ctx, params.Account, order.Certificate)
 	if err != nil {
 		return nil, fmt.Errorf("downloading certificate chain from %s: %w (order=%s)",
 			order.Certificate, err, order.Location)
@@ -216,82 +228,6 @@ func validateOrderIdentifiers(order *acme.Order, csr *x509.CertificateRequest) e
 	}
 
 	return nil
-}
-
-// ObtainCertificateUsingCSR obtains all resulting certificate chains using the given CSR, which
-// must be completely and properly filled out (particularly its DNSNames and Raw fields - this
-// usually involves creating a template CSR, then calling x509.CreateCertificateRequest, then
-// x509.ParseCertificateRequest on the output). The Subject CommonName is NOT considered.
-//
-// It implements every single part of the ACME flow described in RFC 8555 §7.1 with the exception
-// of "Create account" because this method signature does not have a way to return the updated
-// account object. The account's status MUST be "valid" in order to succeed.
-//
-// As far as SANs go, this method currently only supports DNSNames, IPAddresses, Permanent
-// Identifiers and Hardware Module Names on the CSR.
-func (c *Client) ObtainCertificateUsingCSR(ctx context.Context, account acme.Account, csr *x509.CertificateRequest) ([]acme.Certificate, error) {
-	if csr == nil {
-		return nil, errors.New("missing CSR")
-	}
-
-	ids, err := createIdentifiersUsingCSR(csr)
-	if err != nil {
-		return nil, err
-	}
-	if len(ids) == 0 {
-		return nil, errors.New("no identifiers found")
-	}
-
-	csrSource := &csrSource{
-		csr: csr,
-	}
-
-	return c.ObtainCertificateUsingCSRSource(ctx, account, ids, csrSource)
-}
-
-// ObtainCertificate is the same as ObtainCertificateUsingCSR, except it is a slight wrapper
-// that generates the CSR for you. Doing so requires the private key you will be using for
-// the certificate (different from the account private key). It obtains a certificate for
-// the given SANs (domain names) using the provided account.
-func (c *Client) ObtainCertificate(ctx context.Context, account acme.Account, certPrivateKey crypto.Signer, sans []string) ([]acme.Certificate, error) {
-	if len(sans) == 0 {
-		return nil, fmt.Errorf("no DNS names provided: %v", sans)
-	}
-	if certPrivateKey == nil {
-		return nil, fmt.Errorf("missing certificate private key")
-	}
-
-	csrTemplate := new(x509.CertificateRequest)
-	for _, name := range sans {
-		if ip := net.ParseIP(name); ip != nil {
-			csrTemplate.IPAddresses = append(csrTemplate.IPAddresses, ip)
-		} else if strings.Contains(name, "@") {
-			csrTemplate.EmailAddresses = append(csrTemplate.EmailAddresses, name)
-		} else if u, err := url.Parse(name); err == nil && strings.Contains(name, "/") {
-			csrTemplate.URIs = append(csrTemplate.URIs, u)
-		} else {
-			// "The domain name MUST be encoded in the form in which it would appear
-			// in a certificate.  That is, it MUST be encoded according to the rules
-			// in Section 7 of [RFC5280]." §7.1.4
-			normalizedName, err := idna.ToASCII(name)
-			if err != nil {
-				return nil, fmt.Errorf("converting identifier '%s' to ASCII: %v", name, err)
-			}
-			csrTemplate.DNSNames = append(csrTemplate.DNSNames, normalizedName)
-		}
-	}
-
-	// to properly fill out the CSR, we need to create it, then parse it
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, certPrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("generating CSR: %v", err)
-	}
-	csr, err := x509.ParseCertificateRequest(csrDER)
-	if err != nil {
-		return nil, fmt.Errorf("parsing generated CSR: %v", err)
-	}
-
-	return c.ObtainCertificateUsingCSR(ctx, account, csr)
 }
 
 // getAuthzObjects constructs stateful authorization objects for each authz on the order.
@@ -766,28 +702,6 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
-
-// CSRSource is an interface that provides users of this
-// package the ability to provide a CSR as part of the
-// ACME flow. This allows the final CSR to be provided
-// just before the Order is finalized.
-type CSRSource interface {
-	CSR(context.Context) (*x509.CertificateRequest, error)
-}
-
-// csrSource implements the CSRSource interface and is used internally
-// to pass a CSR to ObtainCertificateUsingCSRSource from the existing
-// ObtainCertificateUsingCSR method.
-type csrSource struct {
-	csr *x509.CertificateRequest
-}
-
-func (i *csrSource) CSR(_ context.Context) (*x509.CertificateRequest, error) {
-	return i.csr, nil
-}
-
-// Interface guard
-var _ CSRSource = (*csrSource)(nil)
 
 // retryableErr wraps an error that indicates the caller should retry
 // the operation; specifically with a different challenge type.

--- a/client.go
+++ b/client.go
@@ -56,7 +56,10 @@ type Client struct {
 	ChallengeSolvers map[string]Solver
 }
 
-// ObtainCertificateForSANs is a light wrapper over ObtainCertificate
+// ObtainCertificateForSANs is a light wrapper over ObtainCertificate that generates a simple CSR
+// for the identifiers given in the list of SANs using the given private key; then it obtains a
+// certificate right away. If you require customizing the parameters of the order, use ObtainCertificate
+// instead.
 func (c *Client) ObtainCertificateForSANs(ctx context.Context, account acme.Account, certPrivateKey crypto.Signer, sans []string) ([]acme.Certificate, error) {
 	csr, err := NewCSR(certPrivateKey, sans)
 	if err != nil {

--- a/csr.go
+++ b/csr.go
@@ -15,14 +15,164 @@
 package acmez
 
 import (
+	"context"
+	"crypto"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/mholt/acmez/acme"
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/net/idna"
 )
+
+// NewCSR creates and signs a Certificate Signing Request (CSR) for the given subject
+// identifiers (SANs) with the private key.
+//
+// Supported SAN types are IPs, email addresses, URIs, and DNS names.
+//
+// EXPERIMENTAL: This API is subject to change or removal without a major version bump.
+func NewCSR(privateKey crypto.Signer, sans []string) (*x509.CertificateRequest, error) {
+	if len(sans) == 0 {
+		return nil, fmt.Errorf("no SANs provided: %v", sans)
+	}
+
+	csrTemplate := new(x509.CertificateRequest)
+	for _, name := range sans {
+		if ip := net.ParseIP(name); ip != nil {
+			csrTemplate.IPAddresses = append(csrTemplate.IPAddresses, ip)
+		} else if strings.Contains(name, "@") {
+			csrTemplate.EmailAddresses = append(csrTemplate.EmailAddresses, name)
+		} else if u, err := url.Parse(name); err == nil && strings.Contains(name, "/") {
+			csrTemplate.URIs = append(csrTemplate.URIs, u)
+		} else {
+			// "The domain name MUST be encoded in the form in which it would appear
+			// in a certificate.  That is, it MUST be encoded according to the rules
+			// in Section 7 of [RFC5280]." §7.1.4
+			normalizedName, err := idna.ToASCII(name)
+			if err != nil {
+				return nil, fmt.Errorf("converting identifier '%s' to ASCII: %v", name, err)
+			}
+			csrTemplate.DNSNames = append(csrTemplate.DNSNames, normalizedName)
+		}
+	}
+
+	// to properly fill out the CSR, we need to create it, then parse it
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("generating CSR: %v", err)
+	}
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
+		return nil, fmt.Errorf("parsing generated CSR: %v", err)
+	}
+
+	return csr, nil
+}
+
+// OrderParameters contains high-level input parameters for ACME transactions,
+// the state of which are represented by Order objects. This type is used as a
+// convenient high-level way to convey alk the configuration needed to obtain a
+// certificate (except the private key, which is provided separately to prevent
+// inadvertent exposure of secret material) through ACME in one consolidated value.
+//
+// Account, Subjects, and CSR fields are REQUIRED.
+type OrderParameters struct {
+	// The ACME account with which to perform certificate operations.
+	// It should already be registered with the server and have a
+	// "valid" status.
+	Account acme.Account
+
+	// The list of subjects for which to issue the certificate.
+	// Subjects become Subject Alternate Names (SANs) in the
+	// certificate. This slice must be consistent with the SANs
+	// listed in the CSR. The OrderFromCSR() function can be
+	// used by most users to ensure consistency.
+	//
+	// Supported identifier types are currently: dns, ip,
+	// permanent-identifier, and hardware-module.
+	Subjects []acme.Identifier
+
+	// CSR is a type that can provide the Certificate Signing
+	// Request, which is needed when finalizing the ACME order.
+	// It is used after challenges have completed and before
+	// finalization.
+	CSR CSRSource
+
+	// Optionally customize the lifetime of the certificate by
+	// specifying the NotAfter date for the certificate. Not all
+	// CAs support this. Check your CA's ACME server documentation.
+	NotAfter time.Time
+
+	// Set this if a certificate is being renewed.
+	//
+	// DRAFT: EXPERIMENTAL ARI DRAFT SPEC. Subject to change/removal.
+	Replacing *x509.Certificate
+}
+
+// OrderParametersFromCSR makes a valid OrderParameters from the given CSR.
+// If necessary, it may be further customized before using.
+//
+// EXPERIMENTAL: This API is subject to change or removal without a major version bump.
+func OrderParametersFromCSR(account acme.Account, csr *x509.CertificateRequest) (OrderParameters, error) {
+	ids, err := createIdentifiersUsingCSR(csr)
+	if err != nil {
+		return OrderParameters{}, err
+	}
+	if len(ids) == 0 {
+		return OrderParameters{}, errors.New("no subjects found in CSR")
+	}
+	return OrderParameters{
+		Account:  account,
+		Subjects: ids,
+		CSR:      StaticCSR(csr),
+	}, nil
+}
+
+// CSRSource is an interface that provides users of this
+// package the ability to provide a CSR as part of the
+// ACME flow. This allows the final CSR to be provided
+// just before the Order is finalized, which is useful
+// for certain challenge types (e.g. device-attest-01,
+// where the key used for signing the CSR doesn't exist
+// until the challenge has been validated).
+type CSRSource interface {
+	// CSR returns a Certificate Signing Request that will be
+	// given to the ACME server. This function is called after
+	// an ACME challenge completion and before order finalization.
+	//
+	// The returned CSR must have the Raw field populated with the
+	// DER-encoded certificate request signed by the private key.
+	// Typically this involves creating a template CSR, then calling
+	// x509.CreateCertificateRequest(), then x509.ParseCertificateRequest()
+	// on the output. That should return a valid CSR. The NewCSR()
+	// function in this package does this for you, but if you need more
+	// control you should make it yourself.
+	//
+	// The Subject CommonName field is NOT considered.
+	CSR(context.Context, []acme.Identifier) (*x509.CertificateRequest, error)
+}
+
+// StaticCSR returns a CSRSource that simply returns the input CSR.
+func StaticCSR(csr *x509.CertificateRequest) CSRSource { return staticCSR{csr} }
+
+// staticCSR is a CSRSource that returns an existing CSR.
+type staticCSR struct{ *x509.CertificateRequest }
+
+// CSR returns the associated CSR.
+func (cs staticCSR) CSR(_ context.Context, _ []acme.Identifier) (*x509.CertificateRequest, error) {
+	return cs.CertificateRequest, nil
+}
+
+// Interface guard
+var _ CSRSource = (*staticCSR)(nil)
 
 var (
 	oidExtensionSubjectAltName = []int{2, 5, 29, 17}

--- a/examples/attestation/main.go
+++ b/examples/attestation/main.go
@@ -187,8 +187,13 @@ func attestationExample(csr *x509.CertificateRequest) error {
 		return fmt.Errorf("new account: %v", err)
 	}
 
+	params, err := acmez.OrderParametersFromCSR(account, csr)
+	if err != nil {
+		return fmt.Errorf("order parameters: %v", err)
+	}
+
 	// Do the ACME dance with the created account and get the certificates.
-	certs, err := client.ObtainCertificateUsingCSR(ctx, account, csr)
+	certs, err := client.ObtainCertificate(ctx, params)
 	if err != nil {
 		return fmt.Errorf("obtaining certificate: %v", err)
 	}

--- a/examples/porcelain/main.go
+++ b/examples/porcelain/main.go
@@ -89,7 +89,8 @@ func highLevelExample() error {
 
 	// Before you can get a cert, you'll need an account registered with
 	// the ACME CA; it needs a private key which should obviously be
-	// different from any key used for certificates!
+	// different from any key used for certificates! BE SURE TO SAVE THE
+	// PRIVATE KEY SO YOU CAN REUSE THE ACCOUNT.
 	accountPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return fmt.Errorf("generating account key: %v", err)
@@ -116,10 +117,11 @@ func highLevelExample() error {
 
 	// Once your client, account, and certificate key are all ready,
 	// it's time to request a certificate! The easiest way to do this
-	// is to use ObtainCertificate() and pass in your list of domains
-	// that you want on the cert. But if you need more flexibility, you
-	// should create a CSR yourself and use ObtainCertificateUsingCSR().
-	certs, err := client.ObtainCertificate(ctx, account, certPrivateKey, domains)
+	// is to use ObtainCertificateForSANs() and pass in your list of
+	// domains that you want on the cert. But if you need more
+	// flexibility, you should create a CSR yourself and use
+	// ObtainCertificates().
+	certs, err := client.ObtainCertificateForSANs(ctx, account, certPrivateKey, domains)
 	if err != nil {
 		return fmt.Errorf("obtaining certificate: %v", err)
 	}


### PR DESCRIPTION
This is a new high-level API in the `acmez` package to allow the user more control over ACME orders.

In v1, there are three high-level methods on the `acmez.Client`:

- `ObtainCertificate()`
- `ObtainCertificateForCSR()`
- `ObtainCertificateForCSRSource()`

And their list of arguments was growing quite long, considering we wanted to add support for customizing the NotAfter field of Orders, as well as draft support for ARI which lets you specify a certificate you are replacing/renewing in the Order itself.

To avoid further breaking changes to method signatures brought about by new ACME extensions, I decided to move all the high-level parameters of an Order into a new type, OrderParameters, which encapsulates the user's ACME account, the CSR source, the identifier list, the optional NotAfter, and the optional ID of a cert being renewed (for ARI).

I also wanted to clean up the exported methods so there aren't so many. In v2 there are just:

- `ObtainCertificate()`
- `ObtainCertificateForSANs()`

The first is the more flexible call, but requires that you make an `OrderParameters` struct first. (There are also helper methods for this for the most common use cases.)

The second is more like the original `ObtainCertificate()`, in that it is quite opinionated: it takes the list of SANs as a string slice, the private key, and the account, and will generate the CSR for you along the way. I figure this is the 90% use case, if not more, for this package, so it saves you 2 extra steps (generating the CSR, then generating the order params). But maybe those two steps are easy enough now that they also have helper functions in v2, ObtainCertificateForSANs is not even necessary?

I also changed the CSRSource interface slightly; now it takes the identifiers as an argument. I originally also added the private key as an argument, so it could theoretically have everything it needed to generate the CSR right there, but then it felt weird adding the private key to `ObtainCertificate()`'s signature... maybe because the `StaticCSR()`, which is most commonly used I think, doesn't actually generate a CSR, so we're passing in the private key for nothing. There's no harm in that, just felt weird. I might still restore that.

@hslatman Would you be so kind as to take a look when you have a few minutes? I want to make sure this works for your use case with the more cutting-edge identifier and attestation types... thank you in advance :blush: