### PR TITLE
Added accept header all to requests

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -163,6 +163,7 @@ func (c *Client) httpReq(ctx context.Context, method, endpoint string, joseJSONP
 		}
 		if len(joseJSONPayload) > 0 {
 			req.Header.Set("Content-Type", "application/jose+json")
+			req.Header.Set("Accept", "*/*")
 		}
 
 		// on first attempt, we need to reset buf since it


### PR DESCRIPTION
We found a problem that Buypass.com required the Accept header to work and created a working fix.

Problem so solve:
```
could not get certificate from issuer   {"identifier": "*****************", "issuer": "api.buypass.com-acme-directory", "error": "HTTP 400 about:blank - Required header 'Accept' is not present., url: /acme/cert/*********"}