### PR TITLE
Fix `email-reply-00` response generation and add basic test

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -138,8 +138,13 @@ func (c Challenge) MailReply00KeyAuthorization(mailSubject string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("failed decoding token-part1: %w", err)
 	}
-	fullToken := string(tokenPart1) + c.Token
-	mailKeyAuth := strings.Replace(c.KeyAuthorization, c.Token, fullToken, 1)
+	tokenPart2, err := base64.RawURLEncoding.DecodeString(c.Token)
+	if err != nil {
+		return "", fmt.Errorf("failed decoding token-part2: %w", err)
+	}
+	fullToken := append(tokenPart1, tokenPart2...)
+	encodedFullToken := base64.RawURLEncoding.EncodeToString(fullToken)
+	mailKeyAuth := strings.Replace(c.KeyAuthorization, c.Token, encodedFullToken, 1)
 	h := sha256.Sum256([]byte(mailKeyAuth))
 	return base64.RawURLEncoding.EncodeToString(h[:]), nil
 }

--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"strings"
 )
 
@@ -130,15 +131,17 @@ func (c Challenge) DNS01KeyAuthorization() string {
 // The subject of that mail contains token-part1, which must be combined
 // with token-part2, which was received as part of the JSON challenge as
 // described in RFC8823 §3.1.
-func (c Challenge) MailReply00KeyAuthorization(mailsubject string) string {
+func (c Challenge) MailReply00KeyAuthorization(mailSubject string) (string, error) {
 	// if subject given has "ACME:" header, strip it before calculating the key authorization
-	mailsubject = strings.TrimPrefix(mailsubject, "ACME: ")
-	tokenP1, _ := base64.RawURLEncoding.DecodeString(mailsubject)
-	tokenP2, _ := base64.RawURLEncoding.DecodeString(c.Token)
-	tokenFull := base64.RawURLEncoding.EncodeToString(append(tokenP1, tokenP2...))
-	mailKeyAuth := strings.Replace(c.KeyAuthorization, c.Token, tokenFull, 1)
-	h := sha256.Sum256([]byte(mailsubject + mailKeyAuth))
-	return base64.RawURLEncoding.EncodeToString(h[:])
+	mailSubject = strings.TrimPrefix(mailSubject, "ACME: ")
+	tokenPart1, err := base64.RawURLEncoding.DecodeString(mailSubject)
+	if err != nil {
+		return "", fmt.Errorf("failed decoding token-part1: %w", err)
+	}
+	fullToken := string(tokenPart1) + c.Token
+	mailKeyAuth := strings.Replace(c.KeyAuthorization, c.Token, fullToken, 1)
+	h := sha256.Sum256([]byte(mailKeyAuth))
+	return base64.RawURLEncoding.EncodeToString(h[:]), nil
 }
 
 // InitiateChallenge "indicates to the server that it is ready for the challenge

--- a/mailreply00_test.go
+++ b/mailreply00_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acmez
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/mholt/acmez/v2/acme"
+)
+
+func TestMailReplyChallengeResponse(t *testing.T) {
+	tokenPart2 := "mGVIRa3ZTr3TPSUN"                            // token-part2, obtained through JSON response
+	thumbprint := "e3xcaXlZ7Ur9xZzIuRDt9dP2r5xspalWFCDfjCbFkzg" // fake (raw) base64url encoded account public key
+	c := acme.Challenge{
+		From:             "acmeca@test.example.com",
+		Identifier:       acme.Identifier{Type: "email", Value: "client@test.example.com"},
+		Token:            tokenPart2,
+		KeyAuthorization: fmt.Sprintf("%s.%s", tokenPart2, thumbprint), // with email-reply-00 only 2nd half of token is prefixed
+	}
+	subject := "ACME: dmlxbmw5d2xjT05zWVFGNw" // (raw) base64url encoded token-part1
+	got, err := MailReplyChallengeResponse(c, subject, "messageId", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := mail.ReadMessage(bytes.NewBufferString(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if to := msg.Header.Get("to"); to != "acmeca@test.example.com" {
+		t.Errorf("expected To to be %q, got %q", "acmeca@test.example.com", to)
+	}
+	if from := msg.Header.Get("from"); from != "client@test.example.com" {
+		t.Errorf("expected from to be %q, got %q", "client@test.example.com", from)
+	}
+	if replyTo := msg.Header.Get("in-reply-to"); replyTo != "messageId" {
+		t.Errorf("expected content type to be %q, got %q", "messageId", replyTo)
+	}
+	if subject := msg.Header.Get("subject"); subject != "RE: ACME: dmlxbmw5d2xjT05zWVFGNw" {
+		t.Errorf("expected subject to be %q, got %q", "RE: ACME: dmlxbmw5d2xjT05zWVFGNw", subject)
+	}
+	if contentType := msg.Header.Get("content-type"); contentType != "text/plain" {
+		t.Errorf("expected content type to be %q, got %q", "text/plain", contentType)
+	}
+
+	body, err := io.ReadAll(msg.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	trimmed, _ := strings.CutPrefix(strings.TrimSpace(string(body)), "-----BEGIN ACME RESPONSE-----")
+	trimmed, _ = strings.CutSuffix(trimmed, "-----END ACME RESPONSE-----")
+	trimmed = strings.TrimSpace(trimmed)
+
+	if trimmed != "zPVRe74iorifByo5uXwIgNHOasxE2XHm84f3js1HVmE" {
+		t.Errorf("expected ACME challenge response to be %q, got %q", "zPVRe74iorifByo5uXwIgNHOasxE2XHm84f3js1HVmE", trimmed)
+	}
+}


### PR DESCRIPTION
Some remarks:

- ~This assumes `token-part2` is not necessarily a part of the token that is (raw) base64url encoded, but it does have to use characters from the base64url alphabet. This seems to be in line with other challenges and how ACME clients use the `token` from a JSON response. So, only `token-part1` needs to be decoded, then prefixed to `token-part2` (and the encoded account public key).~
- All of the base64url encoding operations are assumed to be raw base64url encodings, meaning no padding. The RFC includes examples _with_ padding characters, but in my opinion these should all be raw base64url encoding, as that's what is used in all other places where ACME uses base64url encoding. I don't think there's a need to encoded with padding inside an email, specifically.

Have successfully tested this with a customized `step-ca` with support for `email-reply-00`. The fact that I worked on both the client and server part doesn't guarantee the implementation is correct, so it would be great if @orangepizza or someone else can confirm this implementation is correct. 
