### PR TITLE
[fix]: use base64url encoding when reading TNAuthList from csr

### DIFF
--- a/csr.go
+++ b/csr.go
@@ -290,8 +290,11 @@ func createIdentifiersUsingCSR(csr *x509.CertificateRequest) ([]acme.Identifier,
 		// Extract TNAuthList Identifier
 		if ext.Id.Equal(oidExtensionTNAuthList) {
 			ids = append(ids, acme.Identifier{
-				Type:  "TNAuthList",
-				Value: base64.StdEncoding.EncodeToString(ext.Value),
+				Type: "TNAuthList",
+				// https://www.rfc-editor.org/rfc/rfc9448.html#section-3-2
+				// The TNAuthlist value will be base64url encoded
+				// with no padding characters.
+				Value: base64.RawURLEncoding.EncodeToString(ext.Value),
 			})
 		}
 		if ext.Id.Equal(oidExtensionSubjectAltName) {


### PR DESCRIPTION
This PR fixes an issue with previous PR. It switches to using `base64.RawURLEncoding` instead of `base64.StdEncoding` when building TNAuthList Identifier from DER bytes in CSR. 

RFC9448 requires TNAuthList value to be base64url encoded with no padding characters. 
[Reference](https://www.rfc-editor.org/rfc/rfc9448.html#section-3-2)


