### PR TITLE
fix(challenge): use consistent structure

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -135,11 +135,17 @@ func (c Challenge) DNS01KeyAuthorization() string {
 
 // DNSAccount01TXTRecordName returns the name of the TXT record to create
 // for solving the dns-account-01 challenge. §3.2
-func (Challenge) DNSAccount01TXTRecordName(a Account) string {
+//
+// The base32 encoding uses the standard RFC 4648 alphabet (uppercase A-Z),
+// but DNS labels are converted to lowercase for canonical form and
+// interoperability. Some DNS providers (e.g., CloudFront, GlobalSign) enforce
+// lowercase labels, making lowercase conversion essential for reliable operation.
+func (c Challenge) DNSAccount01TXTRecordName(a Account) string {
 	acctURLhash := sha256.Sum256([]byte(a.Location))
 	truncAcctURLHash := acctURLhash[:10]
 	b32TruncAcctURLHash := base32.StdEncoding.EncodeToString(truncAcctURLHash)
-	return fmt.Sprintf("_%s._acme_challenge", b32TruncAcctURLHash)
+	canonicalForm := strings.ToLower(b32TruncAcctURLHash)
+	return fmt.Sprintf("_%s._acme_challenge.%s", canonicalForm, c.Identifier.Value)
 }
 
 // MailReply00KeyAuthorization encodes a key authorization value

--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -138,14 +138,14 @@ func (c Challenge) DNS01KeyAuthorization() string {
 //
 // The base32 encoding uses the standard RFC 4648 alphabet (uppercase A-Z),
 // but DNS labels are converted to lowercase for canonical form and
-// interoperability. Some DNS providers (e.g., CloudFront, GlobalSign) enforce
+// interoperability. Some providers (e.g., CloudFront, GlobalSign) enforce
 // lowercase labels, making lowercase conversion essential for reliable operation.
 func (c Challenge) DNSAccount01TXTRecordName(a Account) string {
 	acctURLhash := sha256.Sum256([]byte(a.Location))
 	truncAcctURLHash := acctURLhash[:10]
 	b32TruncAcctURLHash := base32.StdEncoding.EncodeToString(truncAcctURLHash)
 	canonicalForm := strings.ToLower(b32TruncAcctURLHash)
-	return fmt.Sprintf("_%s._acme_challenge.%s", canonicalForm, c.Identifier.Value)
+	return fmt.Sprintf("_%s._acme-challenge.%s", canonicalForm, c.Identifier.Value)
 }
 
 // MailReply00KeyAuthorization encodes a key authorization value

--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -29,19 +29,19 @@ func TestChallenge_DNSAccount01TXTRecordName(t *testing.T) {
 			name:       "standard account location",
 			account:    Account{Location: "https://acme-v02.api.letsencrypt.org/acme/acct/12345"},
 			identifier: Identifier{Type: "dns", Value: "example.com"},
-			expected:   "_lvrajhh53e27yh7f._acme_challenge.example.com",
+			expected:   "_lvrajhh53e27yh7f._acme-challenge.example.com",
 		},
 		{
 			name:       "different account location",
 			account:    Account{Location: "https://example.com/acme/account/67890"},
 			identifier: Identifier{Type: "dns", Value: "test.example.org"},
-			expected:   "_pbvtvcg2uxbmkni3._acme_challenge.test.example.org",
+			expected:   "_pbvtvcg2uxbmkni3._acme-challenge.test.example.org",
 		},
 		{
 			name:       "empty account location",
 			account:    Account{Location: ""},
 			identifier: Identifier{Type: "dns", Value: "sub.domain.net"},
-			expected:   "_4oymiquy7qobjgx3._acme_challenge.sub.domain.net",
+			expected:   "_4oymiquy7qobjgx3._acme-challenge.sub.domain.net",
 		},
 	}
 

--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acme
+
+import (
+	"testing"
+)
+
+func TestChallenge_DNSAccount01TXTRecordName(t *testing.T) {
+	tests := []struct {
+		name       string
+		account    Account
+		identifier Identifier
+		expected   string
+	}{
+		{
+			name:       "standard account location",
+			account:    Account{Location: "https://acme-v02.api.letsencrypt.org/acme/acct/12345"},
+			identifier: Identifier{Type: "dns", Value: "example.com"},
+			expected:   "_lvrajhh53e27yh7f._acme_challenge.example.com",
+		},
+		{
+			name:       "different account location",
+			account:    Account{Location: "https://example.com/acme/account/67890"},
+			identifier: Identifier{Type: "dns", Value: "test.example.org"},
+			expected:   "_pbvtvcg2uxbmkni3._acme_challenge.test.example.org",
+		},
+		{
+			name:       "empty account location",
+			account:    Account{Location: ""},
+			identifier: Identifier{Type: "dns", Value: "sub.domain.net"},
+			expected:   "_4oymiquy7qobjgx3._acme_challenge.sub.domain.net",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := Challenge{
+				Identifier: test.identifier,
+			}
+			got := c.DNSAccount01TXTRecordName(test.account)
+			if got != test.expected {
+				t.Errorf("DNSAccount01TXTRecordName() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses three corrections to the `DNSAccount01TXTRecordName` implementation as discussed in
https://github.com/mholt/acmez/pull/44#discussion_r2372614151:

**1. FQDN Consistency**
Updates `DNSAccount01TXTRecordName` to return a fully qualified domain name (FQDN), making it consistent with `DNS01TXTRecordName`. This ensures uniform behavior across challenge types.

**2. DNS Label Canonicalization**
Converts base32-encoded labels to lowercase for canonical form and improved interoperability. While DNS is case-insensitive, many DNS providers (including CloudFront) and Certificate Authorities (including GlobalSign) enforce lowercase labels, making this conversion essential for reliable operation across different systems.

**3. Accurate Label**
The original implementation used an invalid underscored sub-label (e.g. `acme_challenge`) when it should be hyphenated (as per [draft-ietf-acme-dns-account-label-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/01/#:~:text=pending%22%2C%0A%20%20%20%20%20%20%20%22token%22%3A%20%22ODE4OWY4NTktYjhmYS00YmY1LTk5MDgtZTFjYTZmNjZlYTUx%22%0A%20%20%20%7D-,3.2.%20%20Challenge%20Fulfillment,-To%20fulfill%20this))