### PR TITLE
Add dns-persist-01 challenge type support

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -97,6 +97,13 @@ type Challenge struct {
 	// and indicates the type of Authority token that will be used
 	// to validate the challenge.
 	TkAuthType string `json:"tkauth-type,omitempty"`
+
+	// IssuerDomainNames is a list of Issuer Domain Names provided by the CA
+	// in a dns-persist-01 challenge. The client selects one to use when
+	// constructing the persistent TXT record value.
+	// Each name is in A-label format, lowercase, without trailing dot.
+	// draft-ietf-acme-dns-persist-00 §4.1
+	IssuerDomainNames []string `json:"issuer-domain-names,omitempty"`
 }
 
 // HTTP01ResourcePath returns the URI path for solving the http-01 challenge.
@@ -171,6 +178,32 @@ func (c Challenge) MailReply00KeyAuthorization(mailSubject string) (string, erro
 	return base64.RawURLEncoding.EncodeToString(h[:]), nil
 }
 
+// DNSPersist01TXTRecordName returns the name of the TXT record to create
+// for the dns-persist-01 challenge.
+//
+// "The Authorization Domain Name is formed by prepending the label
+// '_validation-persist' to the domain name being validated."
+// draft-ietf-acme-dns-persist-00 §4.1
+func (c Challenge) DNSPersist01TXTRecordName() string {
+	return "_validation-persist." + c.Identifier.Value
+}
+
+// DNSPersist01TXTRecordValue constructs the TXT record RDATA for the
+// dns-persist-01 challenge using RFC 8659 issue-value syntax.
+//
+// issuerDomainName should be selected from the challenge's IssuerDomainNames
+// field. The account Location (URI) is used as the accounturi parameter.
+// When wildcard is true, "policy=wildcard" is appended, which authorizes
+// issuance of wildcard certificates and certificates for subdomains.
+// draft-ietf-acme-dns-persist-00 §4.1
+func (c Challenge) DNSPersist01TXTRecordValue(a Account, issuerDomainName string, wildcard bool) string {
+	value := issuerDomainName + "; accounturi=" + a.Location
+	if wildcard {
+		value += "; policy=wildcard"
+	}
+	return value
+}
+
 // InitiateChallenge "indicates to the server that it is ready for the challenge
 // validation by sending an empty JSON body ('{}') carried in a POST request to
 // the challenge URL (not the authorization URL)." §7.5.1
@@ -194,4 +227,5 @@ const (
 	ChallengeTypeEmailReply00   = "email-reply-00"   // RFC 8823 §5.2
 	ChallengeTypeAuthorityToken = "tkauth-01"        // RFC 9447 §3 - ACME Authority Token challenge type
 	ChallengeTypeDNSAccount01   = "dns-account-01"   // draft-ietf-acme-dns-account-label-01 §5
+	ChallengeTypeDNSPersist01   = "dns-persist-01"   // draft-ietf-acme-dns-persist-00
 )

--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -57,3 +57,74 @@ func TestChallenge_DNSAccount01TXTRecordName(t *testing.T) {
 		})
 	}
 }
+
+func TestChallenge_DNSPersist01TXTRecordName(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier Identifier
+		expected   string
+	}{
+		{
+			name:       "apex domain",
+			identifier: Identifier{Type: "dns", Value: "example.com"},
+			expected:   "_validation-persist.example.com",
+		},
+		{
+			name:       "subdomain",
+			identifier: Identifier{Type: "dns", Value: "sub.example.com"},
+			expected:   "_validation-persist.sub.example.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := Challenge{Identifier: test.identifier}
+			got := c.DNSPersist01TXTRecordName()
+			if got != test.expected {
+				t.Errorf("DNSPersist01TXTRecordName() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestChallenge_DNSPersist01TXTRecordValue(t *testing.T) {
+	account := Account{Location: "https://acme-v02.api.letsencrypt.org/acme/acct/12345"}
+
+	tests := []struct {
+		name       string
+		issuer     string
+		wildcard   bool
+		expected   string
+	}{
+		{
+			name:     "without wildcard",
+			issuer:   "letsencrypt.org",
+			wildcard: false,
+			expected: "letsencrypt.org; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+		},
+		{
+			name:     "with wildcard",
+			issuer:   "letsencrypt.org",
+			wildcard: true,
+			expected: "letsencrypt.org; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/12345; policy=wildcard",
+		},
+		{
+			name:     "different issuer",
+			issuer:   "ca.example.net",
+			wildcard: false,
+			expected: "ca.example.net; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/12345",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := Challenge{
+				Identifier: Identifier{Type: "dns", Value: "example.com"},
+			}
+			got := c.DNSPersist01TXTRecordValue(account, test.issuer, test.wildcard)
+			if got != test.expected {
+				t.Errorf("DNSPersist01TXTRecordValue() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support for the `dns-persist-01` ACME challenge type defined in [draft-ietf-acme-dns-persist-00](https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-persist-00).

Following the same pattern as `dns-account-01` (#42), this adds:

- `ChallengeTypeDNSPersist01` constant
- `IssuerDomainNames` field on the `Challenge` struct (the new field specific to this challenge type)
- `DNSPersist01TXTRecordName()` helper (returns `_validation-persist.<domain>`)
- `DNSPersist01TXTRecordValue()` helper (constructs RFC 8659 issue-value syntax with accounturi and optional wildcard policy)
- Tests for both helpers

No solver is included since acmez is bring-your-own-solver. The solver for dns-persist-01 is a no-op in practice since the TXT record is pre-provisioned.

Related: caddyserver/caddy#7495