### PR TITLE
Account for URI SANs and compare identifiers as multisets

### DIFF
--- a/client.go
+++ b/client.go
@@ -240,17 +240,18 @@ func validateOrderIdentifiers(order *acme.Order, csr *x509.CertificateRequest) e
 		return fmt.Errorf("number of identifiers in Order %v (%d) does not match the number of identifiers extracted from CSR %v (%d)", order.Identifiers, len(order.Identifiers), csrIdentifiers, len(csrIdentifiers))
 	}
 
-	identifiers := make([]acme.Identifier, 0, len(order.Identifiers))
-	for _, identifier := range order.Identifiers {
-		for _, csrIdentifier := range csrIdentifiers {
-			if csrIdentifier.Value == identifier.Value && csrIdentifier.Type == identifier.Type {
-				identifiers = append(identifiers, identifier)
-			}
-		}
+	// compare the two sets as multisets: counting matches instead would let a
+	// single CSR identifier satisfy the same Order identifier more than once,
+	// which hides a genuine mismatch elsewhere in the list
+	unmatched := make(map[acme.Identifier]int, len(csrIdentifiers))
+	for _, csrIdentifier := range csrIdentifiers {
+		unmatched[csrIdentifier]++
 	}
-
-	if len(identifiers) != len(csrIdentifiers) {
-		return fmt.Errorf("identifiers in Order %v do not match the identifiers extracted from CSR %v", order.Identifiers, csrIdentifiers)
+	for _, identifier := range order.Identifiers {
+		if unmatched[identifier] == 0 {
+			return fmt.Errorf("identifiers in Order %v do not match the identifiers extracted from CSR %v", order.Identifiers, csrIdentifiers)
+		}
+		unmatched[identifier]--
 	}
 
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -36,6 +36,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"net"
+	"net/url"
 	"testing"
 
 	"github.com/mholt/acmez/v3/acme"
@@ -57,6 +58,15 @@ func marshalOtherName(t *testing.T, oid asn1.ObjectIdentifier, value interface{}
 		t.Fatal(err)
 	}
 	return asn1.RawValue{FullBytes: b}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
 }
 
 func mustMarshal(t *testing.T, val any) []byte {
@@ -172,6 +182,98 @@ func Test_validateOrderIdentifiers(t *testing.T) {
 							}),
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "ok/single-uri",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "uri", Value: "spiffe://example.com/service"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					URIs: []*url.URL{
+						mustParseURL(t, "spiffe://example.com/service"),
+					},
+				},
+			},
+		},
+		{
+			name: "fail/uri-not-in-order",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "dns", Value: "a-dns.example.com"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					DNSNames: []string{"a-dns.example.com"},
+					URIs: []*url.URL{
+						mustParseURL(t, "spiffe://example.com/service"),
+					},
+				},
+			},
+			expErr: errors.New("number of identifiers in Order [{dns a-dns.example.com}] (1) does not match the number of identifiers extracted from CSR [{dns a-dns.example.com} {uri spiffe://example.com/service}] (2)"),
+		},
+		{
+			name: "fail/uri-different-from-order",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "uri", Value: "spiffe://example.com/service"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					URIs: []*url.URL{
+						mustParseURL(t, "spiffe://example.com/other-service"),
+					},
+				},
+			},
+			expErr: errors.New("identifiers in Order [{uri spiffe://example.com/service}] do not match the identifiers extracted from CSR [{uri spiffe://example.com/other-service}]"),
+		},
+		{
+			name: "fail/duplicate-in-order-masks-mismatch",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "dns", Value: "a-dns.example.com"},
+						{Type: "dns", Value: "a-dns.example.com"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					DNSNames: []string{"a-dns.example.com", "another-dns.example.com"},
+				},
+			},
+			expErr: errors.New("identifiers in Order [{dns a-dns.example.com} {dns a-dns.example.com}] do not match the identifiers extracted from CSR [{dns a-dns.example.com} {dns another-dns.example.com}]"),
+		},
+		{
+			name: "fail/duplicate-in-csr-masks-mismatch",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "dns", Value: "a-dns.example.com"},
+						{Type: "dns", Value: "another-dns.example.com"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					DNSNames: []string{"a-dns.example.com", "a-dns.example.com"},
+				},
+			},
+			expErr: errors.New("identifiers in Order [{dns a-dns.example.com} {dns another-dns.example.com}] do not match the identifiers extracted from CSR [{dns a-dns.example.com} {dns a-dns.example.com}]"),
+		},
+		{
+			name: "ok/matching-duplicates",
+			args: args{
+				order: &acme.Order{
+					Identifiers: []acme.Identifier{
+						{Type: "dns", Value: "a-dns.example.com"},
+						{Type: "dns", Value: "a-dns.example.com"},
+					},
+				},
+				csr: &x509.CertificateRequest{
+					DNSNames: []string{"a-dns.example.com", "a-dns.example.com"},
 				},
 			},
 		},

--- a/csr.go
+++ b/csr.go
@@ -283,6 +283,14 @@ func createIdentifiersUsingCSR(csr *x509.CertificateRequest) ([]acme.Identifier,
 			Value: email,
 		})
 	}
+	for _, uri := range csr.URIs {
+		// there's no registered ACME identifier type for URIs, but NewCSR() can put
+		// SANs here, so they need to be accounted for rather than silently dropped
+		ids = append(ids, acme.Identifier{
+			Type:  "uri",
+			Value: uri.String(),
+		})
+	}
 
 	// Extract TNAuthList, permanent identifiers and hardware module values.
 	// This block will ignore errors.


### PR DESCRIPTION
Two small correctness fixes so `validateOrderIdentifiers()` does what its doc comment says. Neither is a security issue: the caller controls both the order identifiers and the CSR, and the CA is still the real authority (Boulder rejects unknown identifier types outright). This is just the client-side fast path, so it should fail fast on inputs the CA is going to reject anyway, and it shouldn't reject inputs that are fine.

**URI SANs were skipped.** `createIdentifiersUsingCSR()` reads DNS names, IPs, emails and the otherName extensions, but never `csr.URIs`. `NewCSR()` routes any SAN containing a slash into that field, and its doc comment lists URIs as a supported SAN type, so a CSR built by this package can carry a URI SAN that no order identifier covers and the check passes. I added them as type `uri` with a comment noting there's no registered ACME identifier type for URIs; the point is that they're accounted for rather than dropped.

**The comparison counted matches instead of comparing multisets.** With order `[a, a]` and CSR `[a, b]` the lengths are equal, `a` matches twice, and `b` is never noticed, so it passes. The counting is wrong in the other direction too: an order and CSR that both legitimately list the same name twice got rejected, because the nested loop appended four matches for a two-element list. Replaced with a count map so each identifier on one side consumes exactly one on the other.

Tests: added cases to `Test_validateOrderIdentifiers` for a URI SAN missing from the order, a URI that differs from the order, both duplicate-masking directions, and matching duplicates. Reverting the two source changes fails six of them:

```
--- FAIL: Test_validateOrderIdentifiers/ok/single-uri
--- FAIL: Test_validateOrderIdentifiers/fail/uri-not-in-order
--- FAIL: Test_validateOrderIdentifiers/fail/uri-different-from-order
--- FAIL: Test_validateOrderIdentifiers/fail/duplicate-in-order-masks-mismatch
--- FAIL: Test_validateOrderIdentifiers/fail/duplicate-in-csr-masks-mismatch
--- FAIL: Test_validateOrderIdentifiers/ok/matching-duplicates
```

With the fix, `go build ./...`, `go vet ./...` and `go test ./...` all pass, and the existing cases are unchanged. Error message wording is untouched so the existing expectations still match.

Happy to drop the URI half if you'd rather not introduce an unregistered identifier type, the two changes are independent.
