### PR TITLE
Do not return an ARI window the client rejected

### DIFF
--- a/acme/ari.go
+++ b/acme/ari.go
@@ -139,9 +139,12 @@ func (c *Client) GetRenewalInfo(ctx context.Context, leafCert *x509.Certificate)
 		return RenewalInfo{}, err
 	}
 
+	const maxAttempts = 3
+
 	var ari RenewalInfo
 	var resp *http.Response
-	for i := 0; i < 3; i++ {
+	var haveWindow bool
+	for i := 0; i < maxAttempts; i++ {
 		// backoff between retries; the if is probably not needed, but just for "properness"...
 		if i > 0 {
 			select {
@@ -184,10 +187,21 @@ func (c *Client) GetRenewalInfo(ctx context.Context, leafCert *x509.Certificate)
 
 		// valid ARI window
 		ari.UniqueIdentifier = certID
+		haveWindow = true
 		break
 	}
 	if err != nil || resp == nil {
 		return RenewalInfo{}, fmt.Errorf("could not get a valid ARI response; last error: %v", err)
+	}
+	// Every attempt answered, but none with a window this client will use.
+	// Returning the last one would hand the caller the very window the loop
+	// above spent all its attempts rejecting, and without a UniqueIdentifier,
+	// since only the accepting path stamps one. Per §4.2 the remedy for a
+	// malformed window is for the client to fall back to its own schedule,
+	// which is what an error lets the caller do.
+	if !haveWindow {
+		return RenewalInfo{}, fmt.Errorf("server did not return a usable ARI window in %d attempts; last window: %s to %s",
+			maxAttempts, ari.SuggestedWindow.Start, ari.SuggestedWindow.End)
 	}
 
 	// "The server SHOULD include a Retry-After header indicating the polling

--- a/acme/ari_test.go
+++ b/acme/ari_test.go
@@ -1,0 +1,160 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acme
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ariTestServer serves just enough of an ACME directory to reach the
+// renewalInfo endpoint, which answers with whatever window the test names.
+// It counts ARI requests so a test can tell a retry loop from a single call.
+func ariTestServer(t *testing.T, window func() (start, end time.Time)) (*Client, *int) {
+	t.Helper()
+
+	var ariRequests int
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/directory", func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"newNonce":    base + "/new-nonce",
+			"newAccount":  base + "/new-account",
+			"newOrder":    base + "/new-order",
+			"renewalInfo": base + "/renewal-info",
+		})
+	})
+
+	mux.HandleFunc("/renewal-info/", func(w http.ResponseWriter, _ *http.Request) {
+		ariRequests++
+		start, end := window()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"suggestedWindow":{"start":%q,"end":%q}}`,
+			start.Format(time.RFC3339), end.Format(time.RFC3339))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &Client{Directory: srv.URL + "/directory"}, &ariRequests
+}
+
+func ariTestCert() *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber:   big.NewInt(0x1234567890),
+		AuthorityKeyId: []byte{0xde, 0xad, 0xbe, 0xef},
+		DNSNames:       []string{"example.com"},
+	}
+}
+
+// A window the client itself rejects must not be handed back as a result.
+//
+// RFC 9773 §4.2: on "a malformed response (e.g. an end timestamp which is
+// equal to or precedes the start timestamp)" the client "SHOULD make its own
+// determination of when to renew the certificate". GetRenewalInfo already
+// classifies these windows as invalid and retries, so returning the last one
+// with a nil error puts the caller on exactly the window the retry loop spent
+// three attempts refusing. See #40, where such a window (from a real Google
+// Trust Services certificate) reached the selection math and panicked.
+func TestGetRenewalInfoRejectsInvalidWindow(t *testing.T) {
+	instant := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+	for _, tc := range []struct {
+		name       string
+		start, end time.Time
+	}{
+		{"zero-length window", instant, instant},
+		{"end precedes start", instant, instant.Add(-time.Hour)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, requests := ariTestServer(t, func() (time.Time, time.Time) {
+				return tc.start, tc.end
+			})
+
+			ari, err := client.GetRenewalInfo(context.Background(), ariTestCert())
+			if err == nil {
+				t.Fatalf("expected an error for a window the client rejected, got %+v (HasWindow=%t, UniqueIdentifier=%q)",
+					ari.SuggestedWindow, ari.HasWindow(), ari.UniqueIdentifier)
+			}
+			if *requests != 3 {
+				t.Errorf("expected 3 attempts before giving up, got %d", *requests)
+			}
+		})
+	}
+}
+
+// The guard against over-correcting: a healthy window still resolves, and the
+// fields a caller keys on are all filled in.
+func TestGetRenewalInfoAcceptsValidWindow(t *testing.T) {
+	start := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	end := start.Add(48 * time.Hour)
+
+	client, requests := ariTestServer(t, func() (time.Time, time.Time) {
+		return start, end
+	})
+
+	ari, err := client.GetRenewalInfo(context.Background(), ariTestCert())
+	if err != nil {
+		t.Fatalf("valid window: %v", err)
+	}
+	if *requests != 1 {
+		t.Errorf("a valid window must be accepted on the first attempt, got %d requests", *requests)
+	}
+	if !ari.HasWindow() {
+		t.Error("HasWindow() must be true for a window the client accepted")
+	}
+	if ari.UniqueIdentifier == "" {
+		t.Error("UniqueIdentifier must be stamped on an accepted result")
+	}
+	if ari.SelectedTime.Before(start) || ari.SelectedTime.After(end) {
+		t.Errorf("SelectedTime %s is outside the suggested window [%s, %s]", ari.SelectedTime, start, end)
+	}
+}
+
+// A window that only becomes valid on a later attempt is what the retry loop
+// exists for, so it must still be picked up.
+func TestGetRenewalInfoRetriesUntilWindowIsValid(t *testing.T) {
+	start := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	end := start.Add(48 * time.Hour)
+
+	attempt := 0
+	client, requests := ariTestServer(t, func() (time.Time, time.Time) {
+		attempt++
+		if attempt < 2 {
+			return start, start // degenerate on the first attempt only
+		}
+		return start, end
+	})
+
+	ari, err := client.GetRenewalInfo(context.Background(), ariTestCert())
+	if err != nil {
+		t.Fatalf("window valid on the second attempt: %v", err)
+	}
+	if *requests != 2 {
+		t.Errorf("expected 2 attempts, got %d", *requests)
+	}
+	if !ari.SuggestedWindow.End.Equal(end) {
+		t.Errorf("expected the second attempt's window, got end=%s", ari.SuggestedWindow.End)
+	}
+}


### PR DESCRIPTION
## What

`GetRenewalInfo` could return a renewal window that it had just rejected, with a `nil` error.

```go
 	var ari RenewalInfo
 	var resp *http.Response
+	var haveWindow bool
 	for i := 0; i < maxAttempts; i++ {
 		…
 		ari.UniqueIdentifier = certID
+		haveWindow = true
 		break
 	}
 	if err != nil || resp == nil { … }
+	if !haveWindow {
+		return RenewalInfo{}, fmt.Errorf("server did not return a usable ARI window in %d attempts; …")
+	}
```

## The path

The loop already classifies a window as malformed exactly the way RFC 9773 §4.2 does — zero-length, or an end at or before the start — logs `invalid ARI window`, and retries. But the check that decides whether the loop succeeded looks only at the transport:

```go
if err != nil || resp == nil {
	return RenewalInfo{}, fmt.Errorf("could not get a valid ARI response; last error: %v", err)
}
```

When all three attempts answer `200` with a malformed window, `err` is nil and `resp` is non-nil, so the function falls through and returns that window as a success. Two things follow:

- **It reads as a real answer downstream.** `HasWindow()` only tests that both timestamps are non-zero, so a zero-length window (`start == end`) passes it. A caller has no way to tell this result apart from an accepted one.
- **`UniqueIdentifier` is empty**, because only the accepting path stamps it — so the result is internally inconsistent with every window this function does accept.

§4.2 says that on a malformed response the client "SHOULD make its own determination of when to renew the certificate". An error is what lets the caller do that; a nil error with a bad window is what stops it.

This is not hypothetical input. #40 is the same class of window — from a real Google Trust Services certificate — reaching the selection math, where it panicked. That crash is fixed; the window that caused it is still accepted.

## Tests

`acme/ari_test.go` is new — `acme/ari.go` had no tests, so the file starts one. It stands up an `httptest` directory whose `renewalInfo` endpoint answers with a window the test names, and counts requests so a retry is distinguishable from a single call.

- `TestGetRenewalInfoRejectsInvalidWindow` — the two shapes §4.2 names (`start == end`, and `end` before `start`). Asserts an error, and that three attempts were made first.
- `TestGetRenewalInfoAcceptsValidWindow` — the guard against over-correcting: a healthy window resolves on the first request, with `HasWindow()`, `UniqueIdentifier` and a `SelectedTime` inside the window.
- `TestGetRenewalInfoRetriesUntilWindowIsValid` — a window that is degenerate on the first attempt and healthy on the second is still picked up, which is what the retry loop is for.

Reverting only `acme/ari.go` fails the first and leaves the other two passing. `go test ./...` is 48 passing, `go vet` clean.

## Behaviour change

A caller that reached this path used to get `(bad window, nil)` and now gets `(RenewalInfo{}, error)`. Callers already have to handle an error here — three transport failures return one, and so does a server without `renewalInfo` in its directory — so this uses a path they have, rather than adding one.
